### PR TITLE
feat: send mail to gmail now possible through form

### DIFF
--- a/backend/routes/contactForm.js
+++ b/backend/routes/contactForm.js
@@ -1,7 +1,35 @@
 import express from "express"
+import nodemailer from "nodemailer";
 import client from "../db.js"
+import dotenv from "dotenv";
 
+dotenv.config();
 const router = express.Router();
+
+const transporter = nodemailer.createTransport({
+    service: "gmail",
+    auth: {
+        user: process.env.EMAIL,
+        pass: process.env.EMAIL_PASSWORD
+    }
+});
+
+const sendEmail = async (formData) => {
+    const mailOptions = {
+        from: process.env.EMAIL,
+        to: process.env.EMAIL,
+        subject: "Meddelande från Portfolio hemsida",
+        text: `Du har fått ett nytt meddelande:\n\nNamn: ${formData.name} ${formData.lastName}\nEmail: ${formData.email}\nMeddelande:\n${formData.message}`
+    };
+
+    try {
+        await transporter.sendMail(mailOptions);
+        console.log("Email skickad!")
+    } catch (err) {
+        console.error("Fel vid mailutskick: ", err);
+    }
+};
+
 
 router.post("/send-form", async (req, res) => {
     try {
@@ -11,6 +39,9 @@ router.post("/send-form", async (req, res) => {
         }
 
         await client.query(`INSERT INTO contact_form (first_name, last_name, email, message_text) VALUES ($1, $2, $3, $4)`, [name || null, lastName || null, email, message]);
+        
+        await sendEmail({name, lastName, email, message});
+
         res.json({message: "Ditt meddelande har skickats!"})
     } catch (err) {
         console.error("Databas Error: ", err);

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@tailwindcss/postcss": "^4.0.13",
         "@tailwindcss/vite": "^4.0.13",
         "axios": "^1.8.3",
+        "nodemailer": "^6.10.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-responsive-carousel": "^3.2.23",
@@ -3566,6 +3567,15 @@
       "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/nodemailer": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.10.0.tgz",
+      "integrity": "sha512-SQ3wZCExjeSatLE/HBaXS5vqUOQk6GtBdIIKxiFdmm01mOQZX/POJkO3SUX1wDiYcwUOJwT23scFSC9fY2H8IA==",
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@tailwindcss/postcss": "^4.0.13",
     "@tailwindcss/vite": "^4.0.13",
     "axios": "^1.8.3",
+    "nodemailer": "^6.10.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-responsive-carousel": "^3.2.23",


### PR DESCRIPTION
The form data is now forwarded via nodemailer, sends a mail to my gmail containing message, name, email.

step 1: Fill in form and send
![image](https://github.com/user-attachments/assets/eda52b65-1c1e-41b8-a949-76bc9e83c6eb)

step 2: Mail recieved in my gmail. 
![image](https://github.com/user-attachments/assets/564f0f25-5379-44f4-8eb2-8a0f4273d7f2)
